### PR TITLE
Add Flask web interface

### DIFF
--- a/main.py
+++ b/main.py
@@ -1220,7 +1220,7 @@ def main():
 
     while True:
         turn_count += 1
-        action = input(f"\n[HP: {player_hp}] [Action]> ").strip()
+        action = input("\nAction> ").strip()
         if action.lower() in ["quit", "exit"]:
             console.print("\n[bold red]Game session ended.[/bold red]\n")
             break

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ console = Console()
 messages = []
 player_stats = {}
 player_hp = 0
+INVENTORY_PREFIX = "@@INV@@"
 danger_ignore_count = 0
 consecutive_danger_failures = 0
 turn_count = 0
@@ -1213,6 +1214,7 @@ def main():
     console.print("[bold magenta]\n🎲 Generating adventure...[/bold magenta]\n")
 
     inventory = load_inventory()
+    print(INVENTORY_PREFIX + " " + "|".join(inventory), flush=True)
     hidden_plot = generate_hidden_plot()
     debug("Hidden Plot:\n" + hidden_plot)
     intro = start_story(hidden_plot, inventory, player_hp)
@@ -1318,6 +1320,7 @@ def main():
         debug(f"🔎 danger_triggered_this_turn before resolve: {danger_triggered_this_turn}")
         outcome, inventory = resolve_action(action, result, damage, fatal, check, inventory, destroyed_item)
         console.print(Markdown("\n" + outcome.strip() + "\n"))
+        print(INVENTORY_PREFIX + " " + "|".join(inventory), flush=True)
 
         if quest_completed:
             console.print("\n[bold green]Quest complete![/bold green]\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ tqdm==4.67.1
 typing-inspection==0.4.1
 typing_extensions==4.14.0
 urllib3==2.4.0
+Flask==3.0.3

--- a/server.py
+++ b/server.py
@@ -19,7 +19,9 @@ def start_game():
     global game_proc, current_inventory
     if game_proc is not None:
         return
-    current_inventory = main.load_inventory()
+    # Start with an empty inventory and let the game process
+    # send the up–to–date list via stdout
+    current_inventory = []
     game_proc = subprocess.Popen(
         ['python', 'main.py'],
         stdin=subprocess.PIPE,

--- a/server.py
+++ b/server.py
@@ -37,7 +37,7 @@ def _reader():
             data = line[len(main.INVENTORY_PREFIX):].strip()
             items = data.split('|') if data else []
             with history_lock:
-                current_inventory = [i for i in items if i]
+                current_inventory = [i.strip() for i in items if i.strip()]
             continue
         output_queue.put(line)
         with history_lock:

--- a/server.py
+++ b/server.py
@@ -23,7 +23,7 @@ def start_game():
     # send the up–to–date list via stdout
     current_inventory = []
     game_proc = subprocess.Popen(
-        ['python', 'main.py'],
+        ['python', '-u', 'main.py'],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -35,8 +35,8 @@ def start_game():
 def _reader():
     global current_inventory
     for line in game_proc.stdout:
-        if line.startswith(main.INVENTORY_PREFIX):
-            data = line[len(main.INVENTORY_PREFIX):].strip()
+        if main.INVENTORY_PREFIX in line:
+            data = line.split(main.INVENTORY_PREFIX,1)[1].strip()
             items = data.split('|') if data else []
             with history_lock:
                 current_inventory = [i.strip() for i in items if i.strip()]

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import queue
 import time
 import os
 import main
+import re
 
 output_history = []
 history_lock = threading.Lock()
@@ -34,9 +35,11 @@ def start_game():
 
 def _reader():
     global current_inventory
-    for line in game_proc.stdout:
+    ansi = re.compile(r'\x1b\[[0-9;]*[mK]')
+    for raw in game_proc.stdout:
+        line = ansi.sub('', raw)
         if main.INVENTORY_PREFIX in line:
-            data = line.split(main.INVENTORY_PREFIX,1)[1].strip()
+            data = line.split(main.INVENTORY_PREFIX, 1)[1].strip()
             items = data.split('|') if data else []
             with history_lock:
                 current_inventory = [i.strip() for i in items if i.strip()]

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>TTRPG Terminal</title>
+<style>
+@font-face {
+    font-family: 'Seagram';
+    src: url('https://github.com/theonlygusti/seagram/releases/download/v1.0/SeagramTFB.ttf') format('truetype');
+}
+body {
+    background: #000;
+    color: #fff;
+    font-family: 'Seagram', monospace;
+    margin: 0;
+    display: flex;
+    height: 100vh;
+}
+#inventory {
+    width: 250px;
+    background: #111;
+    padding: 10px;
+    overflow-y: auto;
+}
+#main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+#terminal {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+}
+#prompt {
+    width: 100%;
+    border: none;
+    padding: 10px;
+    color: #fff;
+    background: #222;
+    font-family: 'Seagram', monospace;
+}
+#health-container {
+    background: #333;
+    height: 20px;
+    margin: 0 10px 10px;
+}
+#health-bar {
+    background: red;
+    height: 100%;
+    width: 100%;
+}
+</style>
+</head>
+<body>
+<div id="inventory">
+  <h3>Inventory</h3>
+  <ul id="inventory-list"></ul>
+</div>
+<div id="main">
+  <div id="health-container"><div id="health-bar"></div></div>
+  <div id="terminal"></div>
+  <input id="prompt" placeholder="Enter command" />
+</div>
+<script>
+const term = document.getElementById('terminal');
+const promptInput = document.getElementById('prompt');
+const healthBar = document.getElementById('health-bar');
+const invList = document.getElementById('inventory-list');
+function append(text){
+    term.textContent += text + '\n';
+    term.scrollTop = term.scrollHeight;
+}
+function refreshStatus(){
+    fetch('/api/status').then(r=>r.json()).then(d=>{
+        if(d.hp){
+            const pct = Math.max(0, d.hp.current/d.hp.max*100);
+            healthBar.style.width = pct + '%';
+        }
+        if(Array.isArray(d.inventory)){
+            invList.innerHTML='';
+            d.inventory.forEach(it=>{const li=document.createElement('li');li.textContent=it;invList.appendChild(li);});
+        }
+    });
+}
+fetch('/api/start').then(r=>r.json()).then(d=>{append(d.intro);refreshStatus();});
+promptInput.addEventListener('keydown',function(e){
+    if(e.key==='Enter'){
+        const cmd = promptInput.value;
+        append('> '+cmd);
+        fetch('/api/command',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({command:cmd})})
+            .then(r=>r.json()).then(d=>{append(d.output);refreshStatus();});
+        promptInput.value='';
+    }
+});
+</script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -17,12 +17,14 @@ body {
     margin: 0;
     display: flex;
     height: 100vh;
+    font-size: 20px;
 }
 #inventory {
     width: 250px;
-    background: #111;
+    background: #000;
     padding: 10px;
     overflow-y: auto;
+    border-right: 1px solid #333;
 }
 #main {
     flex: 1;
@@ -34,24 +36,27 @@ body {
     padding: 10px;
     overflow-y: auto;
     white-space: pre-wrap;
+    font-size: 1em;
 }
 #prompt {
     width: 100%;
     border: none;
     padding: 10px;
     color: #fff;
-    background: #222;
+    background: #000;
     font-family: 'Seagram', monospace;
+    font-size: 1em;
+    border-top: 1px solid #333;
+    outline: none;
 }
 #health-container {
-    background: #333;
-    height: 20px;
-    margin: 0 10px 10px;
+    background: #000;
+    padding: 4px;
 }
-#health-bar {
-    background: red;
-    height: 100%;
-    width: 100%;
+.heart {
+    color: red;
+    margin-right: 2px;
+    font-size: 1.2em;
 }
 </style>
 </head>
@@ -80,8 +85,13 @@ function append(text){
 function refreshStatus(){
     fetch('/api/status').then(r=>r.json()).then(d=>{
         if(d.hp){
-            const pct = Math.max(0, d.hp.current/d.hp.max*100);
-            healthBar.style.width = pct + '%';
+            healthBar.innerHTML='';
+            for(let i=0;i<d.hp.max;i++){
+                const span=document.createElement('span');
+                span.className='heart';
+                span.textContent=i < d.hp.current ? '❤' : '♡';
+                healthBar.appendChild(span);
+            }
         }
         if(Array.isArray(d.inventory)){
             invList.innerHTML='';

--- a/static/index.html
+++ b/static/index.html
@@ -17,7 +17,7 @@ body {
     margin: 0;
     display: flex;
     height: 100vh;
-    font-size: 20px;
+    font-size: 2.5vh;
 }
 #inventory {
     width: 250px;
@@ -57,6 +57,14 @@ body {
     color: red;
     margin-right: 2px;
     font-size: 1.2em;
+    font-family: monospace;
+    display: inline-block;
+    width: 1ch;
+    text-align: center;
+}
+
+.modifier {
+    font-family: monospace;
 }
 </style>
 </head>
@@ -95,7 +103,11 @@ function refreshStatus(){
         }
         if(Array.isArray(d.inventory)){
             invList.innerHTML='';
-            d.inventory.forEach(it=>{const li=document.createElement('li');li.textContent=it;invList.appendChild(li);});
+            d.inventory.forEach(it=>{
+                const li=document.createElement('li');
+                li.innerHTML = it.replace(/\[(.*?)\]/g, '<span class="modifier">[$1]</span>');
+                invList.appendChild(li);
+            });
         }
     });
 }
@@ -108,7 +120,7 @@ fetch('/api/history').then(r=>r.json()).then(d=>{
 });
 
 setInterval(()=>{
-    fetch('/api/poll').then(r=>r.json()).then(d=>append(d.output));
+    fetch('/api/poll').then(r=>r.json()).then(d=>{append(d.output);refreshStatus();});
 },1000);
 promptInput.addEventListener('keydown',function(e){
     if(e.key==='Enter'){

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
 <style>
 @font-face {
     font-family: 'Seagram';
-    src: url('SeagramTFB.ttf') format('truetype');
+    src: url('/SeagramTFB.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -20,11 +20,15 @@ body {
     font-size: 2.5vh;
 }
 #inventory {
-    width: 250px;
+    width: 30vw;
     background: #000;
     padding: 10px;
     overflow-y: auto;
     border-right: 1px solid #333;
+}
+#inventory h3 {
+    text-align: center;
+    margin-top: 0;
 }
 #main {
     flex: 1;
@@ -94,10 +98,10 @@ function refreshStatus(){
     fetch('/api/status').then(r=>r.json()).then(d=>{
         if(d.hp){
             healthBar.innerHTML='';
-            for(let i=0;i<d.hp.max;i++){
+            for(let i=0;i<d.hp.current;i++){
                 const span=document.createElement('span');
                 span.className='heart';
-                span.textContent=i < d.hp.current ? '❤' : '♡';
+                span.textContent='❤';
                 healthBar.appendChild(span);
             }
         }

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,9 @@
 <style>
 @font-face {
     font-family: 'Seagram';
-    src: url('https://github.com/theonlygusti/seagram/releases/download/v1.0/SeagramTFB.ttf') format('truetype');
+    src: url('SeagramTFB.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
 }
 body {
     background: #000;
@@ -69,8 +71,11 @@ const promptInput = document.getElementById('prompt');
 const healthBar = document.getElementById('health-bar');
 const invList = document.getElementById('inventory-list');
 function append(text){
-    term.textContent += text + '\n';
-    term.scrollTop = term.scrollHeight;
+    if(text){
+        term.textContent += text;
+        if(!text.endsWith('\n')) term.textContent += '\n';
+        term.scrollTop = term.scrollHeight;
+    }
 }
 function refreshStatus(){
     fetch('/api/status').then(r=>r.json()).then(d=>{
@@ -84,7 +89,17 @@ function refreshStatus(){
         }
     });
 }
-fetch('/api/start').then(r=>r.json()).then(d=>{append(d.intro);refreshStatus();});
+fetch('/api/history').then(r=>r.json()).then(d=>{
+    append(d.history);
+    refreshStatus();
+    if(!d.history){
+        fetch('/api/start').then(r=>r.json()).then(x=>append(x.intro));
+    }
+});
+
+setInterval(()=>{
+    fetch('/api/poll').then(r=>r.json()).then(d=>append(d.output));
+},1000);
 promptInput.addEventListener('keydown',function(e){
     if(e.key==='Enter'){
         const cmd = promptInput.value;

--- a/static/index.html
+++ b/static/index.html
@@ -37,7 +37,7 @@ body {
 }
 #terminal {
     flex: 1;
-    padding: 10px;
+    padding: 10px 10px 10px 15px;
     overflow-y: auto;
     white-space: pre-wrap;
     font-size: 1em;
@@ -124,7 +124,7 @@ fetch('/api/history').then(r=>r.json()).then(d=>{
     append(d.history);
     refreshStatus();
     if(!d.history){
-        fetch('/api/start').then(r=>r.json()).then(x=>append(x.intro));
+        fetch('/api/start').then(r=>r.json()).then(x=>{append(x.intro);refreshStatus();});
     }
 });
 

--- a/static/index.html
+++ b/static/index.html
@@ -42,20 +42,23 @@ body {
     white-space: pre-wrap;
     font-size: 1em;
 }
+#prompt-row {
+    display: flex;
+    border-top: 1px solid #333;
+}
 #prompt {
-    width: 100%;
+    flex: 1;
     border: none;
     padding: 10px;
     color: #fff;
     background: #000;
     font-family: 'Seagram', monospace;
     font-size: 1em;
-    border-top: 1px solid #333;
     outline: none;
 }
-#health-container {
-    background: #000;
-    padding: 4px;
+#health-bar {
+    padding: 10px 10px 10px 0;
+    white-space: nowrap;
 }
 .heart {
     color: red;
@@ -78,9 +81,11 @@ body {
   <ul id="inventory-list"></ul>
 </div>
 <div id="main">
-  <div id="health-container"><div id="health-bar"></div></div>
   <div id="terminal"></div>
-  <input id="prompt" placeholder="Enter command" />
+  <div id="prompt-row">
+    <input id="prompt" placeholder="Enter command" />
+    <div id="health-bar"></div>
+  </div>
 </div>
 <script>
 const term = document.getElementById('terminal');


### PR DESCRIPTION
## Summary
- add Flask-based `server.py` to host the game and API endpoints
- create `static/index.html` with dark terminal-style UI and health/inventory display
- include Flask in requirements

## Testing
- `python -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_686d5a0b0f24832d8ddc43e1e0cbb00b